### PR TITLE
Add custom SVG favicon with portfolio branding

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,26 @@ export const metadata: Metadata = {
   title: "Troy Garcia - Full Stack Developer",
   description:
     "Full-stack software engineer specializing in MERN stack development, AI integration, and building scalable web applications.",
-  generator: 'v0.dev'
+  generator: 'v0.dev',
+  icons: {
+    icon: [
+      {
+        url: '/favicon.svg',
+        type: 'image/svg+xml',
+      },
+      {
+        url: '/favicon.ico',
+        sizes: '32x32',
+        type: 'image/x-icon',
+      },
+    ],
+    apple: [
+      {
+        url: '/favicon.svg',
+        type: 'image/svg+xml',
+      },
+    ],
+  },
 }
 
 export default function RootLayout({

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,24 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#059669;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#047857;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f0fdf4;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background rounded rectangle -->
+  <rect width="32" height="32" rx="8" ry="8" fill="url(#bgGradient)"/>
+  
+  <!-- Subtle inner shadow effect -->
+  <rect x="1" y="1" width="30" height="30" rx="7" ry="7" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+  
+  <!-- TG Text -->
+  <text x="16" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="url(#textGradient)">TG</text>
+  
+  <!-- Subtle highlight dot -->
+  <circle cx="25" cy="7" r="1.5" fill="rgba(255,255,255,0.3)"/>
+</svg> 


### PR DESCRIPTION
- Create custom SVG favicon (public/favicon.svg) with: • TG initials in emerald/green gradient (#059669 to #047857) • Modern rounded rectangle design with subtle effects • Scalable vector format for crisp display at any size • Matches portfolio's color scheme and branding

- Update app/layout.tsx metadata configuration: • Add SVG favicon reference with proper MIME type • Include fallback ICO reference for browser compatibility • Add Apple touch icon support for iOS devices

- Remove old generic favicon.ico file
- Favicon is now consistent with portfolio design and professional branding